### PR TITLE
ISSUE-1 and 3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         }
     },
     "require": {
-        "adinan-cenci/psr-7": "^1.0",
+        "adinan-cenci/psr-7": "^1.1.3",
         "psr/http-factory": "^1.0"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -8,16 +8,16 @@
     "packages": [
         {
             "name": "adinan-cenci/psr-7",
-            "version": "v1.0.2",
+            "version": "v1.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/adinan-cenci/psr-7.git",
-                "reference": "c0f4be9a98f46a2a5077ac28ad4d970ef61d4a91"
+                "reference": "c148ca67404960aa2b978c694f0e929d18f9f5ec"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/adinan-cenci/psr-7/zipball/c0f4be9a98f46a2a5077ac28ad4d970ef61d4a91",
-                "reference": "c0f4be9a98f46a2a5077ac28ad4d970ef61d4a91",
+                "url": "https://api.github.com/repos/adinan-cenci/psr-7/zipball/c148ca67404960aa2b978c694f0e929d18f9f5ec",
+                "reference": "c148ca67404960aa2b978c694f0e929d18f9f5ec",
                 "shasum": ""
             },
             "require": {
@@ -49,10 +49,10 @@
                 "psr-7"
             ],
             "support": {
-                "source": "https://github.com/adinan-cenci/psr-7/tree/v1.0.2",
+                "source": "https://github.com/adinan-cenci/psr-7/tree/v1.1.3",
                 "issues": "https://github.com/adinan-cenci/psr-7/issues"
             },
-            "time": "2023-01-08T12:29:37+00:00"
+            "time": "2023-08-09T22:54:48+00:00"
         },
         {
             "name": "psr/http-factory",

--- a/src/FormData/FormData.php
+++ b/src/FormData/FormData.php
@@ -1,0 +1,63 @@
+<?php 
+namespace AdinanCenci\Psr17\FormData;
+
+use Psr\Http\Message\StreamInterface;
+
+class FormData 
+{
+    protected string $name = '';
+
+    protected string $value = '';
+
+    protected $file = null;
+
+    protected string $filename = '';
+
+    protected string $tempName = '';
+
+    protected string $contentType = '';
+
+    protected int $size = 0;
+
+    public function __get($var) 
+    {
+        return $this->{$var};
+    }
+
+    public function isFile() : bool
+    {
+        return $this->file != null;
+    }
+
+    public function setName($name) 
+    {
+        $this->name = $name;
+    }
+
+    public function addValue($value) 
+    {
+        if ($this->isFile()) {
+            fwrite($this->file, $value);
+            $this->size += strlen($value);
+        } else {
+            $this->value .= $value;
+        }
+    }
+
+    public function setContentType(string $contentType) 
+    {
+        $this->contentType = $contentType;
+    }
+
+    public function setFilename(string $filename) 
+    {
+        $this->filename = $filename;
+        $this->createFile();
+    }
+
+    protected function createFile() 
+    {
+        $this->file     = tmpfile();
+        $this->tempName = stream_get_meta_data($this->file)['uri'];
+    }
+}

--- a/src/FormData/FormDataParser.php
+++ b/src/FormData/FormDataParser.php
@@ -1,0 +1,86 @@
+<?php 
+namespace AdinanCenci\Psr17\FormData;
+
+use Psr\Http\Message\StreamInterface;
+use Psr\Http\Message\UploadedFileInterface;
+use AdinanCenci\Psr7\UploadedFile;
+use AdinanCenci\Psr17\Helper\Headers;
+
+class FormDataParser 
+{
+    protected bool $headersParsed = false;
+
+    protected FormData $formData;
+
+    public function __construct() 
+    {
+        $this->formData = new FormData();
+    }
+
+    public function addChunk(string $chunk) : void
+    {
+        if (!$chunk) {
+            return;
+        }
+
+        if (!$this->headersParsed) {
+            $parts               = $this->separateHeadersFromBody($chunk);
+            $chunk               = $parts['body'];
+            $this->readHeaders($parts['headers']);
+            $this->headersParsed = true;
+        }
+
+        $this->formData->addValue($chunk);
+    }
+
+    public function getFormData() : FormData
+    {
+        return $this->formData;
+    }
+
+    protected function separateHeadersFromBody(string $chunk) : array
+    {
+        $position = $this->getHeadersEnd($chunk, $lineBreakLenght);
+
+        return [
+            'headers' => substr($chunk, 0, $position),
+            'body'    => substr($chunk, $position + $lineBreakLenght)
+        ];
+    }
+
+    protected function getHeadersEnd(string $chunk, &$lineBreakLenght = 0) : int
+    {
+        if ($pos = strpos($chunk, "\r\n\r\n")) {
+            $lineBreakLenght = 4;
+            return $pos;
+        }
+
+        if ($pos = strpos($chunk, "\n\n")) {
+            $lineBreakLenght = 2;
+            return $pos;
+        }
+        
+        throw new \Exception('fuck this');
+    }
+
+    protected function readHeaders(string $headers) : void
+    {
+        $headerLines = preg_split("/[\r\n]/", $headers);
+
+        foreach ($headerLines as $headerLine) {
+            $header = Headers::parseHeader($headerLine);
+
+            if (isset($header['name'])) {
+                $this->formData->setName($header['name']);
+            }
+
+            if (isset($header['filename'])) {
+                $this->formData->setFilename($header['filename']);
+            }
+
+            if (strtolower($header['headerName']) == 'content-type') {
+                $this->formData->setContentType($header['directive']);
+            }
+        }
+    }
+}

--- a/src/FormData/MultipartFormDataParser.php
+++ b/src/FormData/MultipartFormDataParser.php
@@ -1,0 +1,114 @@
+<?php 
+namespace AdinanCenci\Psr17\FormData;
+
+use Psr\Http\Message\StreamInterface;
+
+class MultipartFormDataParser 
+{
+    protected StreamInterface $stream;
+    protected string $boundary;
+
+    protected array $parts = [];
+    protected $currentPart = null;
+
+    public function __construct(StreamInterface $stream, string $boundary) 
+    {
+        $this->stream   = $stream;
+        $this->boundary = $boundary;
+        $this->boundaryLength = strlen($boundary);
+    }
+
+    /**
+     * @return []FormData
+     */
+    public function parse() : array
+    {
+        $chunkSize   = 8192;
+        $pointer     = 0;
+
+        // Read the first line with the boundary.
+        $this->stream->seek(0);
+        $beginning    = $this->stream->read(150);
+        $this->lookForBoundaryLine($beginning, $this->boundary, $boundaryLineLenght);
+        // Move the pointer to the first part.
+        $this->stream->seek($boundaryLineLenght);
+        $pointer      = $boundaryLineLenght;
+        $this->addChunk('');
+        unset($beginning);
+
+        while ($chunk = $this->stream->read($chunkSize)) {
+            $chunkLength      = strlen($chunk);
+            $boundaryPosition = $this->lookForBoundaryLine($chunk, $this->boundary, $boundaryLineLenght);
+
+            // It is possible for the chunk's end to land on top of the boundary's 
+            // thus failing to detect it. So we read just a bit further, just to make sure.
+            if ($boundaryPosition == -1) {
+                $aBitMore          = $this->stream->read( $this->boundaryLength * 2 );
+                $chunk            .= $aBitMore;
+                $chunkLength      += strlen($aBitMore);
+                $boundaryPosition  = $this->lookForBoundaryLine($chunk, $this->boundary, $boundaryLineLenght);
+            }
+
+            // No Boundary, adds the chunk to current part.
+            if ($boundaryPosition == -1) {
+                $this->addChunk($chunk);
+                $pointer += $chunkLength;
+            // Found a new boundary, this piece of data ends, another begins.
+            } else {
+                $chunkLength  = $boundaryPosition;
+                $chunk        = substr($chunk, 0, $chunkLength);
+                $pointer     += $chunkLength + $boundaryLineLenght;
+
+                $this->addChunk($chunk);
+                $this->newPart();
+
+                $this->stream->seek($pointer);
+            }
+        }
+
+        $formData = [];
+
+        foreach ($this->parts as $p) {
+            $data = $p->getFormData();
+            if ($data->name) {
+                $formData[] = $data;
+            }
+        }
+
+        return $formData;
+    }
+
+    protected function addChunk(string $chunk) : void 
+    {
+        $currentPart = $this->getCurrentPart();
+        $currentPart->addChunk($chunk);
+    }
+
+    protected function getCurrentPart() : FormDataParser
+    {
+        return $this->currentPart = $this->currentPart 
+            ? $this->currentPart
+            : $this->newPart();
+    }
+
+    protected function newPart() : FormDataParser
+    {
+        $newPart = new FormDataParser();
+        $this->parts[] = $this->currentPart = $newPart;
+        return $newPart;
+    }
+
+    protected function lookForBoundaryLine(string $chunk, string $boundary, &$boundaryLineLenght = 0) : int
+    {
+        $regex = "/[\r\n]*-*$this->boundary-*[\r\n]*/";
+        if (preg_match($regex, $chunk, $matches, \PREG_OFFSET_CAPTURE)) {
+            $boundaryLineLenght = strlen($matches[0][0]);
+            return $matches[0][1];
+        }
+
+        $boundaryLineLenght = 0;
+        return -1;
+    }
+}
+
+

--- a/src/Helper/Arrays.php
+++ b/src/Helper/Arrays.php
@@ -1,0 +1,97 @@
+<?php 
+namespace AdinanCenci\Psr17\Helper;
+
+abstract class Arrays 
+{
+    /**
+     * Given an array, it returns ass the key paths to each value contained in it.
+     * 
+     * @param array $array
+     * @param array|null $prefix
+     * @param array|null $root
+     * 
+     * @return (string|int)[]
+     * 
+     * @example
+     *  Arrays::getAllPaths(['foo' => 'bar'])
+     *  will return [ ['foo'] ]
+     */
+    public static function getAllPaths(array $array, ?array $prefix = null, ?array &$root = null) : array
+    {
+        if (is_null($root)) {
+            $root = [];
+        }
+    
+        foreach ($array as $key => $value) {
+            $path = $prefix ? $prefix : [];
+            $path[] = $key;
+    
+            if (!is_array($value)) {
+                $root[] = $path;
+            }
+    
+            if (is_array($value)) {
+               self::getAllPaths($value, $path, $root);
+            }
+        }
+    
+        return $root;
+    }
+
+    /**
+     * Given an $array, it will return the value at the end of the $path of keys.
+     * It returns null if there is nothing there.
+     * 
+     * @param array $array
+     * @param string[] path
+     * 
+     * @return mixed
+     * 
+     * @example
+     *  Array::getValueAtEndOfPath(['foo' => 'bar'], ['foo'])
+     *  Will return 'bar'
+     */
+    public static function getValueAtEndOfPath(array $array, array $path) 
+    {
+        foreach ($path as $p) {
+            if (!isset($array[$p])) {
+                return null;
+            }
+            $array = $array[$p];
+        }
+
+        return $array;
+    }
+
+    /**
+     * Given an $array, it will set a $value at the end of a $path of keys.
+     * 
+     * @param array $array
+     * @param string[] $path
+     * @param mixed $value
+     * 
+     * @return void
+     * 
+     * @example
+     *   Arrays::setValueAtEndOfPath($array, ['foo', 'bar'], 'baz')
+     *   Will set $array['foo']['bar'] as 'baz'
+     */
+    public static function setValueAtEndOfPath(array &$array, array $path, $value) : void
+    {
+        $last = array_pop($path);
+
+        foreach ($path as $key) {
+            if ($key === '') {
+                $array = &$array[];
+            } else {
+                $array = &$array[$key];
+            }
+        }
+
+        if ($last === '') {
+            $array[] = $value;
+        } else {
+            $array[$last] = $value;
+        }
+    }
+}

--- a/src/Helper/Globals.php
+++ b/src/Helper/Globals.php
@@ -131,25 +131,42 @@ abstract class Globals
         $files = [];
 
         foreach ($_FILES as $inputName => $input) {
-            $names    = (array) $input['name'];
-            $types    = (array) $input['type'];
-            $tmpNames = (array) $input['tmp_name'];
-            $errors   = (array) $input['error'];
-            $sizes    = (array) $input['size'];
+            $paths = is_array($_FILES[$inputName]['name']) 
+                ? Arrays::getAllPaths($_FILES[$inputName]['name'])
+                : [$inputName];
 
-            foreach ($names as $key => $name) {
-                $files[] = [
-                    'inputName' => $inputName,
-                    'name'      => $name, 
-                    'type'      => $types[$key],
-                    'tmpName'   => $tmpNames[$key],
-                    'error'     => $errors[$key],
-                    'size'      => $sizes[$key],
-                ];
+            foreach ($paths as $path) {
+                $files[] = self::getUploadedFile($inputName, $path);
             }
         }
 
         return $files;
+    }
+
+    protected static function getUploadedFile(string $inputName, $path) : array
+    {
+        if (is_array($path)) {
+            $fullPath = [$inputName];
+            array_splice($fullPath, 1, count($path), $path);
+
+            return [
+                'path'      => $fullPath,
+                'name'      => Arrays::getValueAtEndOfPath($_FILES[$inputName]['name'], $path), 
+                'type'      => Arrays::getValueAtEndOfPath($_FILES[$inputName]['type'], $path), 
+                'tmpName'   => Arrays::getValueAtEndOfPath($_FILES[$inputName]['tmp_name'], $path), 
+                'error'     => Arrays::getValueAtEndOfPath($_FILES[$inputName]['error'], $path), 
+                'size'      => Arrays::getValueAtEndOfPath($_FILES[$inputName]['size'], $path)
+            ];
+        }
+
+        return [
+            'path'      => [$path],
+            'name'      => $_FILES[$inputName]['name'], 
+            'type'      => $_FILES[$inputName]['type'], 
+            'tmpName'   => $_FILES[$inputName]['tmp_name'], 
+            'error'     => $_FILES[$inputName]['error'], 
+            'size'      => $_FILES[$inputName]['size']
+        ];
     }
 
     protected static function getServerVar($name, $default = '') 

--- a/src/Helper/Globals.php
+++ b/src/Helper/Globals.php
@@ -14,25 +14,11 @@ abstract class Globals
         return $matches[1];
     }
 
-    public static function getMethod(array $headers = []) : string
+    public static function getMethod(array $server = []) : string
     {
-        $method = strtoupper($_SERVER['REQUEST_METHOD']);
-
-        if ($method != 'POST') {
-            return $method;
-        }
-
-        if (! isset($headers['x-http-method-override'])) {
-            return $method;
-        }
-
-        $overriden = strtoupper($headers['x-http-method-override']);
-
-        if (in_array($overriden, ['PUT', 'DELETE', 'PATCH', 'HEAD'])) {
-            $method = $overriden;
-        }
-
-        return $method;
+        return isset($server['REQUEST_METHOD'])
+            ? strtoupper($server['REQUEST_METHOD'])
+            : 'GET';
     }
 
     public static function getHeaders() : array

--- a/src/Helper/Headers.php
+++ b/src/Helper/Headers.php
@@ -1,0 +1,51 @@
+<?php 
+namespace AdinanCenci\Psr17\Helper;
+
+/**
+ * Headers lack standardization, but this crude helper will do for our necessities.
+ */
+abstract class Headers 
+{
+    /**
+     * @param string $header
+     * @return string[] The header as an associative array.
+     * 
+     * @example
+     *   Headers::parseHeader('Content-Disposition: form-data; name="your_input"; filename="foobar.txt"')
+     *   Returns [
+     *     'headerName' => 'Content-Disposition', 
+     *     'directive' => 'form-data', 
+     *     'name' => 'your_input', 
+     *     'filename' => 'foobar.txt'
+     *   ]
+     */
+    public static function parseHeader(string $header) 
+    {
+        $headerName = '';
+        $headerValue = $header;
+
+        if (substr_count($header, ':')) {
+            list($headerName, $headerValue) = preg_split('/ ?: ?/', $header);
+        }
+
+        $parts = [
+            'headerName' => $headerName
+        ];
+
+        $parts['directive'] = preg_match('#^([^;]+);? ?(.*)#', $headerValue, $matches)
+            ? strtolower($matches[1])
+            : $headerValue;
+
+        if (!empty($matches[2])) {
+            $parameters = trim($matches[2]);
+            $parameters = preg_split('/; ?/', $parameters);
+
+            foreach ($parameters as $p) {
+                $split = explode('=', $p);
+                $parts[ $split[0] ] = trim($split[1], '"');
+            }
+        }
+
+        return $parts;
+    }
+}

--- a/src/Helper/Inputs.php
+++ b/src/Helper/Inputs.php
@@ -1,0 +1,25 @@
+<?php 
+namespace AdinanCenci\Psr17\Helper;
+
+abstract class Inputs 
+{
+    public static function insertIntoArray(array &$array, string $inputName, $value) 
+    {
+        $keys = self::splitInputName($inputName);
+        Arrays::setValueAtEndOfPath($array, $keys, $value);
+    }
+
+    /**
+     * @param string $inputName
+     * @return string[]
+     * 
+     * @example 
+     *   Input::splitInputName('person[identification][name]')
+     *   Return ['person', 'identification', 'name']
+     */
+    public static function splitInputName(string $inputName) : array
+    {
+        $keys = preg_split('/[\[\]]{1,2}/', rtrim($inputName, ']'));
+        return $keys;
+    }
+}

--- a/src/UploadedFileFactory.php
+++ b/src/UploadedFileFactory.php
@@ -5,8 +5,10 @@ use Psr\Http\Message\UploadedFileInterface;
 use Psr\Http\Message\UploadedFileFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 
-use AdinanCenci\Psr17\Helper\Globals;
 use AdinanCenci\Psr7\UploadedFile;
+use AdinanCenci\Psr17\Helper\Globals;
+use AdinanCenci\Psr17\Helper\Input;
+use AdinanCenci\Psr17\Helper\Arrays;
 
 class UploadedFileFactory implements UploadedFileFactoryInterface
 {
@@ -28,8 +30,8 @@ class UploadedFileFactory implements UploadedFileFactoryInterface
         $files = Globals::getUploadedFiles();
 
         foreach ($files as $file) {
-            $inputName = $file['inputName'];
-            $uploadedFiles[$inputName][] = new UploadedFile($file['tmpName'], $file['name'], $file['type'], $file['error'], $file['size']);
+            $uploaded = new UploadedFile($file['tmpName'], $file['name'], $file['type'], $file['error'], $file['size']);
+            Arrays::setValueAtEndOfPath($uploadedFiles, $file['path'], $uploaded);
         }
 
         return $uploadedFiles;


### PR DESCRIPTION
## Overview
1. [This library currently does not properly support PUT and other http methods](https://github.com/adinan-cenci/psr-17/issues/1).
  It limits itself to make believe that POST requests are something else over the `x-http-method-override header`.
2. When using array notation in an input's name, `ServerRequestInterface::getUploadedFiles()` must return an array which structure reflects the input's name, [this is currently not the case](https://github.com/adinan-cenci/psr-17/issues/3).

## Solution
1. Now the library parses the multi-part form data in PUT and other http methods, this include uploaded files.
2. Updated the code accordingly.

## Issues
[issue 1](https://github.com/adinan-cenci/psr-17/issues/1)
[issue 3](https://github.com/adinan-cenci/psr-17/issues/3)