### PR TITLE
issue-5: Error while parsing empty form data

### DIFF
--- a/src/FormData/FormDataParser.php
+++ b/src/FormData/FormDataParser.php
@@ -59,8 +59,9 @@ class FormDataParser
             $lineBreakLenght = 2;
             return $pos;
         }
-        
-        throw new \Exception('fuck this');
+
+        $lineBreakLenght = 0;
+        return strlen($chunk);
     }
 
     protected function readHeaders(string $headers) : void


### PR DESCRIPTION
## Overview
When a variable comes empty, an error will be thrown when parsing it.

## Solution
Updated the parser.

## Issue
[Click here](https://github.com/adinan-cenci/psr-17/issues/5)