### PR TITLE
issue-7: Error when instantiating Uri object

### DIFF
--- a/src/Helper/Globals.php
+++ b/src/Helper/Globals.php
@@ -83,17 +83,20 @@ abstract class Globals
         return self::getServerVar('PHP_AUTH_USER');
     }
 
-    public static function getPort() 
-    {
-        $port = self::getServerVar('SERVER_PORT', null);
-        return is_int($port) 
-            ? $port 
-            : null;
-    }
-
     public static function getHost() : string
     {
-        return self::getServerVar('HTTP_HOST', NULL);
+        $host = self::getServerVar('HTTP_X_FORWARDED_HOST', null) ?? self::getServerVar('HTTP_HOST', null);
+        return substr_count($host, ':')
+            ? preg_replace('/:[0-9]+$/', '', $host)
+            : $host;
+    }
+
+    public static function getPort() 
+    {
+        $port = self::getServerVar('HTTP_X_FORWARDED_PORT', null) ?? self::getServerVar('SERVER_PORT', null);
+        return is_numeric($port) 
+            ? $port 
+            : null;
     }
 
     public static function getPath() : string 


### PR DESCRIPTION
## Overview
When accessing the site in a non-standard port like 8000 for example, calling 
`UriFactory::createFromGlobals()` throws an exception.

## Problem
It comes down to `Globals::getHost()` and `Globals::getPort()`, they depend on `$_SERVER['HTTP_HOST']` and `$_SERVER['SERVER_PORT']` respectively, for whatever reason the port is coming attached to `HTTP_HOST`.

## Solution
Updated `Globals::getHost()` and `Globals::getPort()`.

## Issue
[Click here](https://github.com/adinan-cenci/psr-17/issues/7)