### PR TITLE
issue-9: Error when instantiating Uri object 2 electrig boogaloo

### DIFF
--- a/src/Helper/Globals.php
+++ b/src/Helper/Globals.php
@@ -91,11 +91,11 @@ abstract class Globals
             : $host;
     }
 
-    public static function getPort() 
+    public static function getPort() : ?int
     {
         $port = self::getServerVar('HTTP_X_FORWARDED_PORT', null) ?? self::getServerVar('SERVER_PORT', null);
         return is_numeric($port) 
-            ? $port 
+            ? (int) $port 
             : null;
     }
 


### PR DESCRIPTION
## Overview
When accessing the site in a non-standard port like 8000 for example, calling 
`UriFactory::createFromGlobals()` throws an exception.

## Problem
I messed up [PR 8](https://github.com/adinan-cenci/psr-17/pull/8).

## Solution
Updated `Globals::getPort()`.

## Issue
[Click here](https://github.com/adinan-cenci/psr-17/issues/9)